### PR TITLE
Docs: adjusted convertAnnotation documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: PTMods
 Type: Package
-Version: 0.99.5
+Version: 0.99.6
 Title: Managing Post-Translational Modifications in R
 Authors@R: c(person("Laurent", "Gatto", role = "aut",
                     email = "laurent.gatto@uclouvain.be",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # PTMods 0.99
 
+## PTMods 0.99.6 
+
+- Adjusted documentation in `convertAnnotation()`.
+
 ## PTMods 0.99.5
 
 - Import `stats::setNames`.

--- a/R/convertAnnotation.R
+++ b/R/convertAnnotation.R
@@ -32,12 +32,14 @@ utils::globalVariables("modifications")
 #' @details
 #' The function handles three main conversion scenarios:
 #'
-#' - Name to deltaMass: "M[Oxidation]PEPTIDE" -> "M[+15.994915]PEPTIDE"
-#' - Name to unimodId: "M[Oxidation]PEPTIDE" -> "M[UNIMOD:35]PEPTIDE"
-#' - deltaMass to name: "M[+15.995]PEPTIDE" -> "M[Oxidation]PEPTIDE"
-#' - deltaMass to unimodId: "M[+15.995]PEPTIDE" -> "M[UNIMOD:35]PEPTIDE"
-#' - unimodId to name: "M[UNIMOD:35]PEPTIDE" -> "M[Oxidation]PEPTIDE"
-#' - unimodId to deltaMass: "M[UNIMOD:35]PEPTIDE" -> "M[+15.994915]PEPTIDE"
+#' \itemize{
+#'   \item Name to deltaMass: \code{"M[Oxidation]PEPTIDE"} -> \code{"M[+15.994915]PEPTIDE"}
+#'   \item Name to unimodId: \code{"M[Oxidation]PEPTIDE"} -> \code{"M[UNIMOD:35]PEPTIDE"}
+#'   \item deltaMass to name: \code{"M[+15.995]PEPTIDE"} -> \code{"M[Oxidation]PEPTIDE"}
+#'   \item deltaMass to unimodId: \code{"M[+15.995]PEPTIDE"} -> \code{"M[UNIMOD:35]PEPTIDE"}
+#'   \item unimodId to name: \code{"M[UNIMOD:35]PEPTIDE"} -> \code{"M[Oxidation]PEPTIDE"}
+#'   \item unimodId to deltaMass: \code{"M[UNIMOD:35]PEPTIDE"} -> \code{"M[+15.994915]PEPTIDE"}
+#' }
 #'
 #' @examples
 #' # Convert sequence from name to delta mass

--- a/man/convertAnnotation.Rd
+++ b/man/convertAnnotation.Rd
@@ -36,12 +36,14 @@ dataframe (see `?modifications`).
 \details{
 The function handles three main conversion scenarios:
 
-- Name to deltaMass: "M[Oxidation]PEPTIDE" -> "M[+15.994915]PEPTIDE"
-- Name to unimodId: "M[Oxidation]PEPTIDE" -> "M[UNIMOD:35]PEPTIDE"
-- deltaMass to name: "M[+15.995]PEPTIDE" -> "M[Oxidation]PEPTIDE"
-- deltaMass to unimodId: "M[+15.995]PEPTIDE" -> "M[UNIMOD:35]PEPTIDE"
-- unimodId to name: "M[UNIMOD:35]PEPTIDE" -> "M[Oxidation]PEPTIDE"
-- unimodId to deltaMass: "M[UNIMOD:35]PEPTIDE" -> "M[+15.994915]PEPTIDE"
+\itemize{
+  \item Name to deltaMass: \code{"M[Oxidation]PEPTIDE"} -> \code{"M[+15.994915]PEPTIDE"}
+  \item Name to unimodId: \code{"M[Oxidation]PEPTIDE"} -> \code{"M[UNIMOD:35]PEPTIDE"}
+  \item deltaMass to name: \code{"M[+15.995]PEPTIDE"} -> \code{"M[Oxidation]PEPTIDE"}
+  \item deltaMass to unimodId: \code{"M[+15.995]PEPTIDE"} -> \code{"M[UNIMOD:35]PEPTIDE"}
+  \item unimodId to name: \code{"M[UNIMOD:35]PEPTIDE"} -> \code{"M[Oxidation]PEPTIDE"}
+  \item unimodId to deltaMass: \code{"M[UNIMOD:35]PEPTIDE"} -> \code{"M[+15.994915]PEPTIDE"}
+}
 }
 \examples{
 # Convert sequence from name to delta mass


### PR DESCRIPTION
The `convertAnnotation` documentation did not display the supported annotation styles well. 